### PR TITLE
Add thermistor temperatures to homepage

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -95,6 +95,12 @@
                         <table class="cell-voltages" id="CELL_VOLTAGE_TABLE">%CELL_VOLTAGE_TABLE%</table>
                     </td>
                 </tr>
+                <tr>
+                    <th>Thermistor Temperatures</th>
+                    <td>
+                        <table class="cell-voltages" id="TEMPERATURE_TABLE">%TEMPERATURE_TABLE%</table>
+                    </td>
+                </tr>
             </table>
             <hr>
             <form action="/wifi">

--- a/data/index.html
+++ b/data/index.html
@@ -96,7 +96,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>Thermistor Temperatures</th>
+                    <th>Battery/BMS Temps</th>
                     <td>
                         <table class="cell-voltages" id="TEMPERATURE_TABLE">%TEMPERATURE_TABLE%</table>
                     </td>

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -73,6 +73,18 @@ String generateOwieStatusJson() {
     out.concat("<tr>");
   }
 
+  const uint16_t *thermTemps = relay->getTemperaturesCelsius();
+  String temps;
+  temps.reserve(256);
+  temps.concat("<tr>");
+  for (int i = 0; i < 5; i++) {
+      out.concat("<td>");
+      out.concat(thermTemps[i]);
+      out.concat("</td>");
+    }
+  }
+  temps.concat("<tr>");
+
   status["TOTAL_VOLTAGE"] =
       String(relay->getTotalVoltageMillivolts() / 1000.0, 2) + "v";
   status["CURRENT_AMPS"] = String(relay->getCurrentInAmps(), 1) + " Amps";
@@ -83,6 +95,7 @@ String generateOwieStatusJson() {
       String(relay->getRegeneratedChargeMah()) + " mAh";
   status["UPTIME"] = uptimeString();
   status["CELL_VOLTAGE_TABLE"] = out;
+  status["TEMPERATURE_TABLE"] = temps;
 
   serializeJson(status, jsonOutput);
   return jsonOutput;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -57,6 +57,20 @@ String uptimeString() {
   return ret;
 }
 
+String getTempString() {
+  const int8_t *thermTemps = relay->getTemperaturesCelsius();
+  String temps;
+  temps.reserve(256);
+  temps.concat("<tr>");
+  for (int i = 0; i < 5; i++) {
+    temps.concat("<td>");
+    temps.concat(thermTemps[i]);
+    temps.concat("</td>");
+  }
+  temps.concat("<tr>");
+  return temps;
+}
+
 String generateOwieStatusJson() {
   DynamicJsonDocument status(1024);
   String jsonOutput;
@@ -73,17 +87,6 @@ String generateOwieStatusJson() {
     out.concat("<tr>");
   }
 
-  const int8_t *thermTemps = relay->getTemperaturesCelsius();
-  String temps;
-  temps.reserve(256);
-  temps.concat("<tr>");
-  for (int i = 0; i < 5; i++) {
-    temps.concat("<td>");
-    temps.concat(thermTemps[i]);
-    temps.concat("</td>");
-  }
-  temps.concat("<tr>");
-
   status["TOTAL_VOLTAGE"] =
       String(relay->getTotalVoltageMillivolts() / 1000.0, 2) + "v";
   status["CURRENT_AMPS"] = String(relay->getCurrentInAmps(), 1) + " Amps";
@@ -94,7 +97,7 @@ String generateOwieStatusJson() {
       String(relay->getRegeneratedChargeMah()) + " mAh";
   status["UPTIME"] = uptimeString();
   status["CELL_VOLTAGE_TABLE"] = out;
-  status["TEMPERATURE_TABLE"] = temps;
+  status["TEMPERATURE_TABLE"] = getTempString();
 
   serializeJson(status, jsonOutput);
   return jsonOutput;
@@ -156,17 +159,7 @@ String templateProcessor(const String &var) {
     }
     return out;
   } else if (var == "TEMPERATURE_TABLE") {
-    const int8_t *thermTemps = relay->getTemperaturesCelsius();
-    String temps;
-    temps.reserve(256);
-    temps.concat("<tr>");
-    for (int i = 0; i < 5; i++) {
-      temps.concat("<td>");
-      temps.concat(thermTemps[i]);
-      temps.concat("</td>");
-    }
-    temps.concat("<tr>");
-    return temps;
+    return getTempString();
   } else if (var == "AP_PASSWORD") {
     return Settings->ap_self_password;
   } else if (var == "AP_SELF_NAME") {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -73,15 +73,14 @@ String generateOwieStatusJson() {
     out.concat("<tr>");
   }
 
-  const uint16_t *thermTemps = relay->getTemperaturesCelsius();
+  const int8_t *thermTemps = relay->getTemperaturesCelsius();
   String temps;
   temps.reserve(256);
   temps.concat("<tr>");
   for (int i = 0; i < 5; i++) {
-      out.concat("<td>");
-      out.concat(thermTemps[i]);
-      out.concat("</td>");
-    }
+    temps.concat("<td>");
+    temps.concat(thermTemps[i]);
+    temps.concat("</td>");
   }
   temps.concat("<tr>");
 
@@ -156,6 +155,18 @@ String templateProcessor(const String &var) {
       out.concat("<tr>");
     }
     return out;
+  } else if (var == "TEMPERATURE_TABLE") {
+    const int8_t *thermTemps = relay->getTemperaturesCelsius();
+    String temps;
+    temps.reserve(256);
+    temps.concat("<tr>");
+    for (int i = 0; i < 5; i++) {
+      temps.concat("<td>");
+      temps.concat(thermTemps[i]);
+      temps.concat("</td>");
+    }
+    temps.concat("<tr>");
+    return temps;
   } else if (var == "AP_PASSWORD") {
     return Settings->ap_self_password;
   } else if (var == "AP_SELF_NAME") {


### PR DESCRIPTION
This diff adds thermistor temperatures to the homepage using existing built in methods to fetch them.

This is super useful for troubleshooting temperature errors that may be caused either by crushed thermistors, disconnected contacts, or actually out of range temperatures.

Tested on my personal OWIE/board.  Works great.