### PR TITLE
Improved battery percentage tracking based off actual energy remaining

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -21,7 +21,7 @@ AsyncWebSocket ws("/rawdata");
 const String defaultPass("****");
 BmsRelay *relay;
 
-const String owie_version = "1.4.2";
+const String owie_version = "1.4.3";
 
 String renderPacketStatsTable() {
   String result(


### PR DESCRIPTION
The existing method of battery percentage tracking is lacking in my experience.

The majority of implementations of battery tracking either track linearly with voltage (CB/JW charts), or with amp hours used (FM stock).  Neither are accurate, rather Wh (energy) should be used to track as it is the actual indicator of remaining range.

My understanding is that current implementation is based off experimental results on a single pint, however different batteries using different cell types or configurations will be wildly inaccurate (confirmed on my personal XR).  The existing implementation has several sticky points, as well as some edge cases where negative.  This leads to tons of range remaining at 0% as well as a non linear relationship between % and range.

This solution tracks remaining battery as a function of the voltage of the lowest cell, however the voltage -> % points were not tracked linearly, but rather using [the following chart](https://lygte-info.dk/pic/Batteries2012/Sony%20US18650VTC6%203000mAh%20(Green)/Sony%20US18650VTC6%203000mAh%20(Green)-Energy.png) that links voltage to remaining energy.   VTC6 was chosen as it is the stock cell used in XRs and Pints, and additionally, its discharge curve is very very similar to a Molicel m35a typically used in JW and CB batteries.

The following chart shows the differences between the old and new % calculation for various cell voltages.  This chart aligns much more closely with my personal experience with both OWIE on a stock pack, as well as a 15s2p pack using Samsung 50s's. 

Cell voltage,  New %, Old %
2700,	0,	95
2710,	0,	95
2720,	0,	95
2730,	0,	95
2740,	0,	95
2750,	0,	95
2760,	0,	95
2770,	0,	0
2780,	0,	0
2790,	0,	0
2800,	0,	0
2810,	0,	0
2820,	0,	0
2830,	0,	0
2840,	0,	0
2850,	0,	0
2860,	0,	0
2870,	0,	0
2880,	0,	0
2890,	0,	0
2900,	0,	0
2910,	0,	0
2920,	0,	0
2930,	0,	0
2940,	0,	0
2950,	0,	0
2960,	0,	0
2970,	0,	0
2980,	0,	0
2990,	0,	0
3000,	1,	0
3010,	1,	0
3020,	1,	0
3030,	1,	0
3040,	1,	0
3050,	2,	0
3060,	2,	0
3070,	2,	0
3080,	2,	0
3090,	3,	0
3100,	3,	0
3110,	3,	1
3120,	4,	1
3130,	4,	1
3140,	4,	1
3150,	5,	1
3160,	5,	1
3170,	5,	1
3180,	6,	2
3190,	6,	2
3200,	7,	2
3210,	7,	2
3220,	8,	2
3230,	8,	2
3240,	8,	2
3250,	9,	3
3260,	9,	3
3270,	10,	3
3280,	10,	3
3290,	11,	3
3300,	11,	3
3310,	12,	4
3320,	12,	4
3330,	13,	5
3340,	14,	5
3350,	14,	6
3360,	15,	6
3370,	15,	7
3380,	16,	7
3390,	17,	8
3400,	17,	8
3410,	18,	9
3420,	18,	9
3430,	19,	10
3440,	20,	10
3450,	20,	11
3460,	21,	12
3470,	22,	13
3480,	23,	14
3490,	23,	15
3500,	24,	16
3510,	25,	17
3520,	26,	18
3530,	26,	20
3540,	27,	21
3550,	28,	22
3560,	29,	23
3570,	29,	24
3580,	30,	25
3590,	31,	26
3600,	32,	28
3610,	33,	29
3620,	34,	30
3630,	35,	32
3640,	35,	33
3650,	36,	34
3660,	37,	35
3670,	38,	37
3680,	39,	38
3690,	40,	39
3700,	41,	41
3710,	42,	42
3720,	43,	43
3730,	44,	45
3740,	45,	46
3750,	46,	47
3760,	47,	48
3770,	48,	50
3780,	49,	51
3790,	50,	52
3800,	51,	53
3810,	52,	55
3820,	53,	56
3830,	54,	57
3840,	55,	58
3850,	57,	60
3860,	58,	61
3870,	59,	62
3880,	60,	63
3890,	61,	64
3900,	62,	66
3910,	63,	67
3920,	65,	68
3930,	66,	69
3940,	67,	71
3950,	68,	72
3960,	69,	73
3970,	71,	74
3980,	72,	76
3990,	73,	77
4000,	75,	78
4010,	76,	80
4020,	77,	82
4030,	78,	83
4040,	80,	85
4050,	81,	86
4060,	82,	88
4070,	84,	90
4080,	85,	91
4090,	86,	93
4100,	88,	94
4110,	89,	96
4120,	91,	98
4130,	92,	99
4140,	93,	95
4150,	95,	95
4160,	96,	95
4170,	98,	95
4180,	99,	95
4190,	100,	95
4200,	100,	95
4210,	100,	95
4220,	100,	95
4230,	100,	95
4240,	100,	95