### PR TITLE
[Lookup table version] Improved battery percentage tracking based off actual energy remaining

### DIFF
--- a/lib/bms/packet_parsers.cpp
+++ b/lib/bms/packet_parsers.cpp
@@ -26,7 +26,7 @@ int openCircuitSocFromCellVoltage(uint16_t cellVoltageMillivolts) {
   static constexpr uint16_t range = lookupTableRangeMaxMv - lookupTableRangeMinMv;
   static constexpr uint16_t LOOKUP_TABLE_STEPS = 30;
   static constexpr uint16_t stepSize = range / LOOKUP_TABLE_STEPS; // 50
-  static uint8_t LOOKUP_TABLE[LOOKUP_TABLE_STEPS + 2] = {0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 7, 8, 11, 14, 16, 18, 19, 25, 30, 33, 37, 43, 48, 53, 60, 67, 71, 76, 82, 92, 97, 100};
+  static uint8_t LOOKUP_TABLE[LOOKUP_TABLE_STEPS + 2] = {0, 0, 0, 0, 1, 2, 3, 4, 5, 7, 8, 11, 14, 16, 18, 19, 25, 30, 33, 37, 43, 48, 53, 60, 67, 71, 76, 82, 92, 97, 100, 100};
   int voltage_scalar = clamp<uint16_t>(cellVoltageMillivolts - lookupTableRangeMinMv, 0, range);
   int leftIndex = clamp<int>(voltage_scalar / stepSize, 0, LOOKUP_TABLE_STEPS);
   int rightIndex = leftIndex + 1;

--- a/lib/bms/packet_parsers.cpp
+++ b/lib/bms/packet_parsers.cpp
@@ -26,6 +26,7 @@ int openCircuitSocFromCellVoltage(uint16_t cellVoltageMillivolts) {
   static constexpr uint16_t range = lookupTableRangeMaxMv - lookupTableRangeMinMv;
   static constexpr uint16_t LOOKUP_TABLE_STEPS = 30;
   static constexpr uint16_t stepSize = range / LOOKUP_TABLE_STEPS; // 50
+  // Adding this + 2 prevents out of bounds errors, simply padded an extra 0 and 100 on either side.
   static uint8_t LOOKUP_TABLE[LOOKUP_TABLE_STEPS + 2] = {0, 0, 0, 0, 1, 2, 3, 4, 5, 7, 8, 11, 14, 16, 18, 19, 25, 30, 33, 37, 43, 48, 53, 60, 67, 71, 76, 82, 92, 97, 100, 100};
   int voltage_scalar = clamp<uint16_t>(cellVoltageMillivolts - lookupTableRangeMinMv, 0, range);
   int leftIndex = clamp<int>(voltage_scalar / stepSize, 0, LOOKUP_TABLE_STEPS);


### PR DESCRIPTION
Basically the same as the previous PR except this uses a larger lookup table instead of converting that lookup table to a best fit polynomial.  As discussed, only lookup tables solutions are considered acceptable and a polynomial based solution will not be merged in.

The existing method of battery percentage tracking is lacking in my experience.

The majority of implementations of battery tracking either track linearly with voltage (CB/JW charts), or with amp hours used (FM stock). Neither are accurate, rather Wh (energy) should be used to track as it is the actual indicator of remaining range.

My understanding is that current implementation is based off experimental results on a single pint, however different batteries using different cell types or configurations will be wildly inaccurate (confirmed on my personal XR). The existing implementation has several sticky points, as well as some edge cases where negative. This leads to tons of range remaining at 0% as well as a non linear relationship between % and range.

This solution tracks remaining battery as a function of the voltage of the lowest cell, however the voltage -> % points were not tracked linearly, but rather using [the following chart](https://lygte-info.dk/pic/Batteries2012/Sony%20US18650VTC6%203000mAh%20(Green)/Sony%20US18650VTC6%203000mAh%20(Green)-Energy.png) that links voltage to remaining energy. VTC6 was chosen as it is the stock cell used in XRs and Pints, and additionally, its discharge curve is very very similar to a Molicel m35a typically used in JW and CB batteries.

The following chart shows the differences between the old and new % calculation for various cell voltages. This chart aligns much more closely with my personal experience with both OWIE on a stock pack, as well as a 15s2p pack using Samsung 50s's.

Millivolts/Old%/New%

2700,95,0
2705,95,0
2710,95,0
2715,95,0
2720,95,0
2725,95,0
2730,95,0
2735,95,0
2740,95,0
2745,95,0
2750,95,0
2755,95,0
2760,95,0
2765,0,0
2770,0,0
2775,0,0
2780,0,0
2785,0,0
2790,0,0
2795,0,0
2800,0,0
2805,0,0
2810,0,0
2815,0,0
2820,0,0
2825,0,0
2830,0,0
2835,0,0
2840,0,0
2845,0,0
2850,0,0
2855,0,0
2860,0,0
2865,0,0
2870,0,0
2875,0,0
2880,0,0
2885,0,0
2890,0,0
2895,0,0
2900,0,1
2905,0,1
2910,0,1
2915,0,1
2920,0,1
2925,0,1
2930,0,1
2935,0,1
2940,0,1
2945,0,1
2950,0,2
2955,0,2
2960,0,2
2965,0,2
2970,0,2
2975,0,2
2980,0,2
2985,0,2
2990,0,2
2995,0,2
3000,0,3
3005,0,3
3010,0,3
3015,0,3
3020,0,3
3025,0,3
3030,0,3
3035,0,3
3040,0,3
3045,0,3
3050,0,4
3055,0,4
3060,0,4
3065,0,4
3070,0,4
3075,0,4
3080,0,4
3085,0,4
3090,0,4
3095,0,4
3100,0,5
3105,1,5
3110,1,5
3115,1,5
3120,1,5
3125,1,6
3130,1,6
3135,1,6
3140,1,6
3145,1,6
3150,1,7
3155,1,7
3160,1,7
3165,1,7
3170,1,7
3175,2,7
3180,2,7
3185,2,7
3190,2,7
3195,2,7
3200,2,8
3205,2,8
3210,2,8
3215,2,8
3220,2,9
3225,2,9
3230,2,9
3235,2,10
3240,2,10
3245,3,10
3250,3,11
3255,3,11
3260,3,11
3265,3,11
3270,3,12
3275,3,12
3280,3,12
3285,3,13
3290,3,13
3295,3,13
3300,3,14
3305,3,14
3310,4,14
3315,4,14
3320,4,14
3325,4,15
3330,5,15
3335,5,15
3340,5,15
3345,5,15
3350,6,16
3355,6,16
3360,6,16
3365,6,16
3370,7,16
3375,7,17
3380,7,17
3385,7,17
3390,8,17
3395,8,17
3400,8,18
3405,8,18
3410,9,18
3415,9,18
3420,9,18
3425,9,18
3430,10,18
3435,10,18
3440,10,18
3445,10,18
3450,11,19
3455,11,19
3460,12,20
3465,12,20
3470,13,21
3475,14,22
3480,14,22
3485,15,23
3490,15,23
3495,16,24
3500,16,25
3505,17,25
3510,17,26
3515,18,26
3520,18,27
3525,19,27
3530,20,28
3535,20,28
3540,21,29
3545,21,29
3550,22,30
3555,22,30
3560,23,30
3565,23,30
3570,24,31
3575,25,31
3580,25,31
3585,26,32
3590,26,32
3595,27,32
3600,28,33
3605,28,33
3610,29,33
3615,30,34
3620,30,34
3625,31,35
3630,32,35
3635,32,35
3640,33,36
3645,34,36
3650,34,37
3655,35,37
3660,35,38
3665,36,38
3670,37,39
3675,37,40
3680,38,40
3685,39,41
3690,39,41
3695,40,42
3700,41,43
3705,41,43
3710,42,44
3715,43,44
3720,43,45
3725,44,45
3730,45,46
3735,45,46
3740,46,47
3745,46,47
3750,47,48
3755,48,48
3760,48,49
3765,49,49
3770,50,50
3775,50,50
3780,51,51
3785,51,51
3790,52,52
3795,53,52
3800,53,53
3805,54,53
3810,55,54
3815,55,55
3820,56,55
3825,56,56
3830,57,57
3835,58,57
3840,58,58
3845,59,59
3850,60,60
3855,60,60
3860,61,61
3865,61,62
3870,62,62
3875,63,63
3880,63,64
3885,64,64
3890,64,65
3895,65,66
3900,66,67
3905,66,67
3910,67,67
3915,68,68
3920,68,68
3925,69,69
3930,69,69
3935,70,69
3940,71,70
3945,71,70
3950,72,71
3955,73,71
3960,73,72
3965,74,72
3970,74,73
3975,75,73
3980,76,74
3985,76,74
3990,77,75
3995,78,75
4000,78,76
4005,79,76
4010,80,77
4015,81,77
4020,82,78
4025,82,79
4030,83,79
4035,84,80
4040,85,80
4045,86,81
4050,86,82
4055,87,83
4060,88,84
4065,89,85
4070,90,86
4075,90,87
4080,91,88
4085,92,89
4090,93,90
4095,94,91
4100,94,92
4105,95,92
4110,96,93
4115,97,93
4120,98,94
4125,98,94
4130,99,95
4135,98,95
4140,95,96
4145,95,96
4150,95,97
4155,95,97
4160,95,97
4165,95,97
4170,95,98
4175,95,98
4180,95,98
4185,95,99
4190,95,99
4195,95,99
4200,95,100
4205,95,100
4210,95,100
4215,95,100
4220,95,100
4225,95,100
4230,95,100
4235,95,100
4240,95,100
4245,95,100