### PR TITLE
Track battery % using consumed mAh instead of voltage.

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -74,6 +74,10 @@
                     <td id="OVERRIDDEN_SOC">%OVERRIDDEN_SOC%%%</td>
                 </tr>
                 <tr>
+                    <th>Charge State mAh:</th>
+                    <td id="CHARGE_STATE_MAH">%CHARGE_STATE_MAH% mAh</td>
+                </tr>
+                <tr>
                     <th>Used charge:</th>
                     <td id="USED_CHARGE_MAH">%USED_CHARGE_MAH% mAh</td>
                 </tr>

--- a/data/settings.html
+++ b/data/settings.html
@@ -35,6 +35,10 @@
         </button>
       </fieldset>
       <fieldset>
+        <legend>Battery Capacity:</legend>
+        <p>Capacity:<br><input type="number" placeholder="6000" value="%BATTERY_MAH%" name="battery_mah"></p>
+      </fieldset>
+      <fieldset>
         <legend>Firmware Update:</legend>
         <input id="updInput" type="file" name="firmware" accept=".bin,.bin.gz">
       </fieldset>

--- a/lib/bms/packet_parsers.cpp
+++ b/lib/bms/packet_parsers.cpp
@@ -17,24 +17,16 @@ inline int16_t int16FromNetworkOrder(const void* const p) {
   return ((uint16_t)(*charPointer)) << 8 | *(charPointer + 1);
 }
 
-int openCircuitSocFromCellVoltage(int cellVoltageMillivolts) {
-  static constexpr int LOOKUP_TABLE_RANGE_MIN_MV = 2700;
-  static constexpr int LOOKUP_TABLE_RANGE_MAX_MV = 4200;
-  static uint8_t LOOKUP_TABLE[31] = {0, 0, 0, 0, 1, 2, 3, 4, 5, 7, 8, 11, 14, 16, 18, 19, 25, 30, 33, 37, 43, 48, 53, 60, 67, 71, 76, 82, 92, 97, 100};
-  static constexpr int LOOKUP_TABLE_SIZE = (sizeof(LOOKUP_TABLE)/sizeof(*LOOKUP_TABLE));
-  static constexpr int RANGE = LOOKUP_TABLE_RANGE_MAX_MV - LOOKUP_TABLE_RANGE_MIN_MV;
-  // (RANGE - 1) upper limit effectively clamps the leftIndex below to (LOOKUP_TABLE_SIZE - 2)
-  cellVoltageMillivolts = clamp(cellVoltageMillivolts - LOOKUP_TABLE_RANGE_MIN_MV, 0, RANGE - 1);
-  float floatIndex = float(cellVoltageMillivolts) * (LOOKUP_TABLE_SIZE - 1) / RANGE;
-  const int leftIndex = int(floatIndex);
-  const float fractional = floatIndex - leftIndex;
-  const int rightIndex = leftIndex + 1;
-  const int leftValue = LOOKUP_TABLE[leftIndex];
-  const int rightValue = LOOKUP_TABLE[rightIndex];
-  return leftValue + round((rightValue - leftValue) * fractional);
+}  // namespace
+
+int BmsRelay::consumedSoc(int maxMah) {
+  return round((float(-getChargeStateMah()) / float(maxMah)) * 100);
 }
 
-}  // namespace
+int BmsRelay::socFromMahUsed(int maxMah) {
+    return std::min(100 - consumedSoc(maxMah), 100);
+}
+
 
 void BmsRelay::batteryPercentageParser(Packet& p) {
   if (p.getType() != 3) {
@@ -49,6 +41,9 @@ void BmsRelay::batteryPercentageParser(Packet& p) {
   }
   overridden_soc_percent_ =
       openCircuitSocFromCellVoltage(filtered_lowest_cell_voltage_millivolts_);
+  if (mah_max_ != 0 && overridden_soc_percent_ > 15) { // For the last 15%, switch over to voltage tracking
+    overridden_soc_percent_ = socFromMahUsed(mah_max_);
+  }
   p.data()[0] = overridden_soc_percent_;
 }
 
@@ -125,6 +120,16 @@ void BmsRelay::cellVoltageParser(Packet& p) {
   }
   filtered_lowest_cell_voltage_millivolts_ =
       lowest_cell_voltage_filter_.step(min_voltage);
+
+
+  // Correct the battery state if we dont have a full battery but think we do.
+  if (mah_state_ >= 0 && filtered_lowest_cell_voltage_millivolts_ < 4190) {
+    mah_state_ = batteryStateEstimate();
+  } 
+  // If the battery is full, and we are not moving or charging, reset state.
+  if(filtered_lowest_cell_voltage_millivolts_ >= 4190 && getCurrentInAmps() > -0.2 && mah_state_ != 0) {
+    setChargeStateMah(0);
+  }
 }
 
 void BmsRelay::temperatureParser(Packet& p) {

--- a/proto/settings.proto
+++ b/proto/settings.proto
@@ -13,4 +13,6 @@ message SettingsMsg {
   bool is_locked = 9; // if the board is actively locked/parked
   bool locking_enabled = 10; // if the board locking functionality is enabled ('armed')
   reserved 11;
+  int32 mah_state = 12;
+  int32 mah_max = 13;
 }

--- a/src/bms_main.cpp
+++ b/src/bms_main.cpp
@@ -65,10 +65,16 @@ void bms_setup() {
 
   relay->setPowerOffCallback([]() {
     Settings->graceful_shutdown_count++;
+    Settings->mah_state = relay->getChargeStateMah();
+    //Settings->mah_max = relay->batteryCapacityEstimate();
     saveSettings();
   });
 
   relay->setBMSSerialOverride(0xFFABCDEF);
+
+  relay->setChargeStateMah(Settings->mah_state);
+  relay->setMaxMah(Settings->mah_max);
+
 
   setupWifi();
   setupWebServer(relay);


### PR DESCRIPTION
This PR introduces the concept of battery % (SOC) tracking using mAh instead of a voltage table.

The new system tracks SOC using both voltage and mAh in parallel, and only uses mAh if the following conditions are true

- The user has set a battery capacity > 0 in the settings
- The SOC as determined by voltage is > 15% (this prevents sudden nosedives at low voltage if the mAh is misconfigured or bugged).

