### PR TITLE
Report received and overridden BMS serial number in UI.

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -82,6 +82,22 @@
                     <td id="REGENERATED_CHARGE_MAH">%REGENERATED_CHARGE_MAH% mAh</td>
                 </tr>
                 <tr>
+                    <th>Received Serial (Dec):</th>
+                    <td id="RECEIVED_SERIAL_DEC">%RECEIVED_SERIAL_DEC%</td>
+                </tr>
+                <tr>
+                    <th>Received Serial (Hex):</th>
+                    <td id="RECEIVED_SERIAL_HEX">%RECEIVED_SERIAL_HEX%</td>
+                </tr>
+                <tr>
+                    <th>Sent Serial (Dec):</th>
+                    <td id="SENT_SERIAL_DEC">%SENT_SERIAL_DEC%</td>
+                </tr>
+                <tr>
+                    <th>Sent Serial (Hex):</th>
+                    <td id="SENT_SERIAL_HEX">%SENT_SERIAL_HEX%</td>
+                </tr>
+                <tr>
                     <th>Uptime:</th>
                     <td id="UPTIME">%UPTIME%</td>
                 </tr>

--- a/lib/bms/bms_relay.h
+++ b/lib/bms/bms_relay.h
@@ -66,6 +66,13 @@ class BmsRelay {
   uint32_t getCapturedBMSSerial() { return captured_serial_; }
 
   /**
+   * @brief Get the BMS serial override value.
+   *
+   * @return The serial override value, or 0 if not set.
+   */
+  uint32_t getBMSSerialOverride() { return serial_override_; }
+
+  /**
    * @brief Battery percentage as reported by the BMS.
    */
   int8_t getBmsReportedSOC() { return bms_soc_percent_; }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -119,6 +119,19 @@ String generateOwieStatusJson() {
   status["CELL_VOLTAGE_TABLE"] = out;
   status["TEMPERATURE_TABLE"] = getTempString();
 
+  // BMS Serial Numbers
+  char hexBuf[16];
+  uint32_t capturedSerial = relay->getCapturedBMSSerial();
+  uint32_t overrideSerial = relay->getBMSSerialOverride();
+
+  status["RECEIVED_SERIAL_DEC"] = String(capturedSerial);
+  snprintf(hexBuf, sizeof(hexBuf), "0x%X", capturedSerial);
+  status["RECEIVED_SERIAL_HEX"] = String(hexBuf);
+
+  status["SENT_SERIAL_DEC"] = String(overrideSerial);
+  snprintf(hexBuf, sizeof(hexBuf), "0x%X", overrideSerial);
+  status["SENT_SERIAL_HEX"] = String(hexBuf);
+
   serializeJson(status, jsonOutput);
   return jsonOutput;
 }
@@ -194,6 +207,18 @@ String templateProcessor(const String &var) {
     return out;
   } else if (var == "TEMPERATURE_TABLE") {
     return getTempString();
+  } else if (var == "RECEIVED_SERIAL_DEC") {
+    return String(relay->getCapturedBMSSerial());
+  } else if (var == "RECEIVED_SERIAL_HEX") {
+    char hexBuf[16];
+    snprintf(hexBuf, sizeof(hexBuf), "0x%X", relay->getCapturedBMSSerial());
+    return String(hexBuf);
+  } else if (var == "SENT_SERIAL_DEC") {
+    return String(relay->getBMSSerialOverride());
+  } else if (var == "SENT_SERIAL_HEX") {
+    char hexBuf[16];
+    snprintf(hexBuf, sizeof(hexBuf), "0x%X", relay->getBMSSerialOverride());
+    return String(hexBuf);
   } else if (var == "AP_PASSWORD") {
     return Settings->ap_self_password;
   } else if (var == "AP_SELF_NAME") {


### PR DESCRIPTION
Exposes BMS's actual serial number in UI in DEC and HEX format + reports overridden serial number same way.

<img width="430" height="669" alt="image" src="https://github.com/user-attachments/assets/dd77e9b4-fade-4948-97d8-99c852d5f7a4" />

