### PR TITLE
Update GitHub Actions.

### DIFF
--- a/.github/workflows/build_and_test_all.yml
+++ b/.github/workflows/build_and_test_all.yml
@@ -4,21 +4,21 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Cache PlatformIO
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.platformio
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
       - name: Install PlatformIO and html-minifier-terser
         run: |
           python -m pip install --upgrade pip
@@ -31,7 +31,7 @@ jobs:
       - name: Build Owie
         run: pio run -e d1_mini_lite_clone
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: firmware
           path: .pio/build/d1_mini_lite_clone/firmware.bin

--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: build-and-test
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: firmware
           path: ./firmware.bin


### PR DESCRIPTION
GitHub actions failing with:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: 
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 
```

Updates:
* .github/workflows/build_and_test_all.yml:
  * actions/checkout@v3 → @v4
  * actions/cache@v3 → @v4 (both pip and PlatformIO caches)
  * actions/setup-python@v2 → @v5
  * actions/upload-artifact@v3 → @v4

* .github/workflows/tagged_release.yml:
  * actions/download-artifact@v3 → @v4