### PR TITLE
Fix test_battery_fuel_gauge: drop redundant guard, harden onHighestDischarge

### DIFF
--- a/lib/bms/battery_fuel_gauge.cc
+++ b/lib/bms/battery_fuel_gauge.cc
@@ -77,11 +77,6 @@ void BatteryFuelGauge::updateVoltage(int32_t voltageMillivolts,
 
 void BatteryFuelGauge::updateCurrent(int32_t currentMilliamps,
                                      int32_t nowMillis) {
-  // Ignore current updates until we see first voltage message
-  if (voltage_millivolts_ < 0) {
-    return;
-  }
-
   defer { last_current_update_time_millis_ = nowMillis; };
   if (last_current_update_time_millis_ < 0) {
     return;

--- a/lib/bms/battery_fuel_gauge.cc
+++ b/lib/bms/battery_fuel_gauge.cc
@@ -121,6 +121,11 @@ void BatteryFuelGauge::onHighestCharge() {
 }
 
 void BatteryFuelGauge::onHighestDischarge() {
+  // Skip until we have a voltage-derived SOC; otherwise the unsigned
+  // comparisons below would assign the sentinel -1 to bottomSoc.
+  if (voltage_based_soc_ < 0) {
+    return;
+  }
   // Maintain an invariant of topSoc >= bottomSoc
   if (voltage_based_soc_ > state_.topSoc) {
     return;


### PR DESCRIPTION
## Why

CI (added in #83) surfaced two failing assertions in `test_battery_fuel_gauge`:

```
test/test_battery_fuel_gauge/battery_fuel_gauge_test.cpp:21:testCurrentRideSpentAndRegeneratedStats:FAIL: Expected 123 Was 0
test/test_battery_fuel_gauge/battery_fuel_gauge_test.cpp:71:testSimpleChargeAndHalfwayDischarge:FAIL: Expected 3600000 Was 3599400
```

Root cause: the `voltage_millivolts_ < 0` early-return in `updateCurrent` (added in b6a4936) silently drops the first batch of current samples whenever no voltage sample has been observed yet. After `restoreState()` the transient `voltage_millivolts_` resets to `-1`, so legitimate coulomb counting is lost until the next voltage packet arrives. The first `updateCurrent` call is already disregarded by the existing `last_current_update_time_millis_ < 0` check (which seeds the timestamp baseline), so the voltage guard was redundant for its stated purpose ("Ignore current updates until we see first voltage message").

## What

1. **`updateCurrent`** — remove the redundant `voltage_millivolts_ < 0` guard. The first call still only seeds the timestamp; subsequent calls count coulombs unconditionally.
2. **`onHighestDischarge`** — add an explicit `voltage_based_soc_ < 0` early-return. This is the real safety net the broad guard was masking: when a fresh-boot device sees a current sample before any voltage sample, `currentMilliampSeconds` can exceed `bottomMilliampSeconds` and trigger `onHighestDischarge`. Without this check the function would assign `bottomSoc = -1` (the sentinel), which then propagates into `getSoc()` and produces a transient negative SOC. `onHighestCharge` is incidentally safe (its `<=` check short-circuits on `-1`), but `onHighestDischarge` had no equivalent guard.

## Functional impact

| Scenario | Before | After |
|---|---|---|
| Fresh boot, voltage packet first | OK | OK |
| Fresh boot, current packet first | Coulombs dropped until voltage arrives | Coulombs counted; `bottomSoc` stays valid via the new guard |
| After `restoreState`, current first | Coulombs dropped until voltage arrives (test failure) | Coulombs counted from the saved state |
| Steady state | OK | OK |

## Test

- `pio test -e native` — all 18 tests pass locally (was 16/18)
- Tests now exercise the correct contract: the first `updateCurrent` seeds the timestamp; subsequent calls always count